### PR TITLE
Add Unicode infinity

### DIFF
--- a/lib/Lingua/EN/Numbers.pm
+++ b/lib/Lingua/EN/Numbers.pm
@@ -7,6 +7,8 @@ require Exporter;
 use 5.006;
 use strict;
 use warnings;
+use utf8;
+
 BEGIN { *DEBUG = sub () {0} unless defined &DEBUG } # setup a DEBUG constant
 use vars qw(
  @EXPORT @EXPORT_OK $VERSION
@@ -62,14 +64,16 @@ sub num2en_ordinal {
 
 #==========================================================================
 
+my $infinity = qr/(?:inf(?:inity)?|∞)/;
+
 sub num2en {
   my $x = $_[0];
   return undef unless defined $x and length $x;
 
   return 'not-a-number'      if $x eq 'NaN';
-  return 'positive infinity' if $x =~ m/^\+inf(?:inity)?$/si;
-  return 'negative infinity' if $x =~ m/^\-inf(?:inity)?$/si;
-  return          'infinity' if $x =~  m/^inf(?:inity)?$/si;
+  return 'positive infinity' if $x =~ m/^\+$infinity$/si;
+  return 'negative infinity' if $x =~ m/^\-$infinity$/si;
+  return          'infinity' if $x =~  m/^$infinity$/si;
 
   return $D{$x} if exists $D{$x};  # the most common cases
 

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -6,4 +6,5 @@ use Lingua::EN::Numbers 'num2en';
 my $wide = '１.２３';
 my $out = num2en ($wide);
 ok (! defined $out);
+is (num2en ('∞'), 'infinity');
 done_testing ();


### PR DESCRIPTION
This adds Unicode infinity to the recognised values.

This may fail on Perl 5.6 or earlier. I haven't tested it. It also
required changing to "use utf8".
