### PR TITLE
Fix leading zero issues

### DIFF
--- a/lib/Lingua/EN/Numbers.pm
+++ b/lib/Lingua/EN/Numbers.pm
@@ -1,6 +1,5 @@
 
 package Lingua::EN::Numbers;
-
 require Exporter;
 @ISA = qw(Exporter);
 
@@ -125,7 +124,8 @@ sub _int2en {
   my($x) = $_[0];
 
   return $D{$x} if defined $D{$x};  # most common/irreg cases
-  
+  # Strip leading 0s, leaving last digit untouched, might be 0. 
+  $x =~ s/^0+(?=[0-9])//; 
   if( $x =~ m/^(.)(.)$/ ) {
     return  $D{$1 . '0'} . '-' . $D{$2};
      # like    forty        -     two

--- a/t/20_main_integers.t
+++ b/t/20_main_integers.t
@@ -4,7 +4,7 @@ require 5;
 use strict;
 use Test;
 
-BEGIN { plan tests => 18 }
+BEGIN { plan tests => 23 }
 
 use Lingua::EN::Numbers;
 ok 1;
@@ -15,6 +15,7 @@ sub N { Lingua::EN::Numbers::num2en($_[0]) }
 
 ok N(0), "zero";
 ok N('0'), "zero";
+ok N('00'), "zero";
 ok N('-0'), "negative zero";
 ok N('0.0'), "zero point zero";
 ok N('.0'), "point zero";
@@ -24,6 +25,11 @@ ok N(3), "three";
 ok N(4), "four";
 ok N(40), "forty";
 ok N(42), "forty-two";
+ok N('7'), "seven";
+ok N('07'), "seven";
+ok N('007'), "seven";
+ok N('0007'), "seven";
+
 
 
 ok N(400), "four hundred";


### PR DESCRIPTION
So, this module came up as  my pull request club assignment. I took a look the rt bug  #118691, and accept your basic premise that this module converts numbers, not strings. No-one would ever write oh-oh-seven (except for this time), so 007 should become 7. The original bug said that 07 returns -seven and gives a warning - which it still does. 007 actual become "zero hundred and seven". So, my fix is to remove leading 0s in _int2en. At that point we know the data is as string of digits. In principle we could add 0, but that's likely to go wrong with big numbers. The only 'trick' as such is to make sure that a single 0 doesn't become the empty string. 